### PR TITLE
result info added when search query executed with no results

### DIFF
--- a/second-react/news-app/src/App.js
+++ b/second-react/news-app/src/App.js
@@ -58,8 +58,6 @@ export default class App extends Component {
   render() {
     return (
       <>
-      {console.log(process.env.REACT_APP_NEWS_API_KEY)}
-      {console.log(process.env.NODE_ENV)}
         <LoadingBar
           color='#f11946'
           progress={this.state.progress}

--- a/second-react/news-app/src/components/News.js
+++ b/second-react/news-app/src/components/News.js
@@ -22,7 +22,7 @@ export class News extends Component {
     constructor() {
         super();
         this.state = {
-            articles: null,
+            articles: null,  // empty array will be good in place of null.
             loading: true,
             page: 1,
         }
@@ -71,7 +71,8 @@ export class News extends Component {
         return (
             <>
                 <div className='my-4' style={{marginLeft: '5rem'}}>
-                    <h2 className='container'>Top Headlines - {this.props.category === 'general' || this.props.category === "" ? "Global" : this.props.category}</h2>
+                {this.parsedData?.articles == 0 ? <h2 className='container'>{this.props.category === 'general' || this.props.category === "" ? "Global" : this.props.category} - No Result Found for '{this.props.searchText}'</h2> :
+                    <h2 className='container'>Top Headlines - {this.props.category === 'general' || this.props.category === "" ? "Global" : this.props.category}</h2>}
                 </div>
                 
                 {/* displaying loader when page refreshed */}

--- a/second-react/news-app/src/components/NewsItem.js
+++ b/second-react/news-app/src/components/NewsItem.js
@@ -7,7 +7,7 @@ export class NewsItem extends Component {
     render() {
 
         // accessing some props
-        let { title, desc, newsUrl, imgUrl, authorName, publishedAt } = this.props;
+        let { title, desc, newsUrl, imgUrl, authorName, publishedAt} = this.props;
         let date = new Date(publishedAt);
 
         return (
@@ -26,6 +26,7 @@ export class NewsItem extends Component {
                     </div>
                 </div>
             </>
+            
         )
     }
 }


### PR DESCRIPTION
When we enter a search query in the search box and send the request to API and API sends no result for the particular search text, then a simple text will be visible to display no result found.